### PR TITLE
Modifying logic to check ONC data download status

### DIFF
--- a/my-next-app/src/app/chat/page.tsx
+++ b/my-next-app/src/app/chat/page.tsx
@@ -109,7 +109,7 @@ export default function OceansChatBot() {
         <ChatArea
           messages={currentChat?.messages || []}
           title="What do you want to know?"
-          example="What is the average temperature in Cambridge bay?"
+          example="How thick was the ice in Cambridge Bay in February this year?"
           onFeedback={handleFeedback}
         />
 

--- a/my-next-app/src/app/chat/page.tsx
+++ b/my-next-app/src/app/chat/page.tsx
@@ -5,6 +5,8 @@ import { ChatSidebar } from "@/components/ChatSidebar"
 import { ChatArea } from "@/components/ChatArea"
 import { ChatInput } from "@/components/ChatInput"
 import { ConnectionStatus } from "@/components/ConnectionStatus"
+import { DownloadCompletePopup } from "@/components/DownloadCompletePopup"
+import { useDownloadManager } from "@/hooks/use-download-manager"
 import { useChatAPI } from "@/hooks/use-chat-api"
 import { useEffect } from "react"
 
@@ -22,6 +24,8 @@ export default function OceansChatBot() {
     setCurrentChat,
     initializeApp,
   } = useChatAPI()
+
+  const { completedDownloads, dismissCompleted, activeDownloads } = useDownloadManager()
 
   const handleNewChat = () => {
     setCurrentChat(null)
@@ -105,7 +109,7 @@ export default function OceansChatBot() {
         <ChatArea
           messages={currentChat?.messages || []}
           title="What do you want to know?"
-          example="How thick was the ice in Cambridge Bay on February this year?"
+          example="What is the average temperature in Cambridge bay?"
           onFeedback={handleFeedback}
         />
 
@@ -131,6 +135,24 @@ export default function OceansChatBot() {
           </div>
         )}
       </div>
+
+      {/* Download complete popups */}
+      {completedDownloads.map((requestId) => {
+        const downloadJob = activeDownloads[requestId]
+        return (
+          <DownloadCompletePopup
+            key={requestId}
+            requestId={requestId}
+            onDownload={() => {
+              if (downloadJob?.downloadUrl) {
+                window.open(downloadJob.downloadUrl, "_blank", "noopener,noreferrer")
+              }
+              dismissCompleted(requestId)
+            }}
+            onDismiss={() => dismissCompleted(requestId)}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/my-next-app/src/components/ChatArea.tsx
+++ b/my-next-app/src/components/ChatArea.tsx
@@ -107,7 +107,7 @@ export function ChatArea({
                     message.dpRequestId.trim() !== "" && (
                       <div className="flex justify-start">
                         <div className="w-fit max-w-[85%] sm:max-w-[75%] ml-0">
-                          <DownloadLinks link={message.downloadLink} />
+                          <DownloadLinks dpRequestId={message.dpRequestId} />
                         </div>
                       </div>
                     )}

--- a/my-next-app/src/components/ChatArea.tsx
+++ b/my-next-app/src/components/ChatArea.tsx
@@ -52,64 +52,70 @@ export function ChatArea({
       <ScrollArea ref={scrollAreaRef} className="flex-1 min-h-0">
         <div className="p-4">
           <div className="max-w-1xl mx-auto space-y-4">
-            {messages.map((message) => (
-              <div key={message.id}>
-                <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
-                  <div
-                    className={`max-w-[70%] rounded-2xl px-4 py-3 ${
-                      message.role === "user"
-                        ? "bg-blue-600 text-white rounded-br-md"
-                        : "bg-gray-200 text-gray-800 rounded-bl-md"
-                    } ${message.content === "Processing..." ? "animate-pulse" : ""}`}
-                  >
-                    <p className="text-sm leading-relaxed">
-                      {message.content}
-                      {message.content === "Processing..." && (
-                        <span className="inline-block ml-1">
-                          <span className="animate-pulse">.</span>
-                          <span className="animate-pulse animation-delay-200">.</span>
-                          <span className="animate-pulse animation-delay-400">.</span>
-                        </span>
-                      )}
-                    </p>
-                    <p className={`text-xs mt-1 ${message.role === "user" ? "text-blue-100" : "text-gray-500"}`}>
-                      {message.timestamp.toLocaleTimeString([], {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </p>
+            {messages.map((message, index) => {
+              return (
+                <div key={message.id}>
+                  <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
+                    <div
+                      className={`max-w-[70%] rounded-2xl px-4 py-3 ${
+                        message.role === "user"
+                          ? "bg-blue-600 text-white rounded-br-md"
+                          : "bg-gray-200 text-gray-800 rounded-bl-md"
+                      } ${message.content === "Processing..." ? "animate-pulse" : ""}`}
+                    >
+                      <div className="text-sm leading-relaxed">
+                        {message.content === "Processing..." ? (
+                          <>
+                            Processing
+                            <span className="inline-block ml-1">
+                              <span className="animate-pulse">.</span>
+                              <span className="animate-pulse animation-delay-200">.</span>
+                              <span className="animate-pulse animation-delay-400">.</span>
+                            </span>
+                          </>
+                        ) : (
+                          message.content
+                        )}
+                      </div>
+                      <p className={`text-xs mt-1 ${message.role === "user" ? "text-blue-100" : "text-gray-500"}`}>
+                        {message.timestamp.toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </p>
+                    </div>
                   </div>
+
+                  {/* Show data product download if request_id exists */}
+                  {message.role === "assistant" &&
+                    message.content !== "Processing..." &&
+                    message.dpRequestId &&
+                    message.dpRequestId.trim() !== "" && (
+                      <div className="flex justify-start">
+                        <div className="max-w-[70%] ml-0">
+                          <DownloadLinks dpRequestId={message.dpRequestId} />
+                        </div>
+                      </div>
+                    )}
+
+                  {/* Show feedback component for assistant messages */}
+                  {message.role === "assistant" &&
+                    message.content !== "Processing..." &&
+                    message.messageId &&
+                    onFeedback && (
+                      <div className="flex justify-start">
+                        <div className="max-w-[70%] ml-0">
+                          <MessageFeedback
+                            messageId={message.messageId}
+                            onFeedback={onFeedback}
+                            currentFeedback={message.feedback?.rating}
+                          />
+                        </div>
+                      </div>
+                    )}
                 </div>
-
-                {/* Show download link for assistant messages with a valid link */}
-                {message.role === "assistant" &&
-                  message.content !== "Processing..." &&
-                  message.downloadLink &&
-                  message.downloadLink !== "no" && (
-                    <div className="flex justify-start">
-                      <div className="max-w-[70%] ml-0">
-                        <DownloadLinks link={message.downloadLink} />
-                      </div>
-                    </div>
-                  )}
-
-                {/* Show feedback component for assistant messages (but not processing messages) */}
-                {message.role === "assistant" &&
-                  message.content !== "Processing..." &&
-                  message.id &&
-                  onFeedback && (
-                    <div className="flex justify-start">
-                      <div className="max-w-[70%] ml-0">
-                        <MessageFeedback
-                          messageId={message.id}
-                          onFeedback={onFeedback}
-                          currentFeedback={message.feedback?.rating}
-                        />
-                      </div>
-                    </div>
-                  )}
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </ScrollArea>

--- a/my-next-app/src/components/ChatArea.tsx
+++ b/my-next-app/src/components/ChatArea.tsx
@@ -8,6 +8,8 @@ import { AnimatedProcessingText } from "./AnimatedProcessingText"
 import type { Message } from "@/types/chat"
 import TTSButton from "@/components/TTSButton"
 import { TerritorialAcknowledgement } from "@/components/TerritorialAcknowledgement"
+import OncApiDownloadStarter from "@/components/OncDownloadStarter"
+import { useDownloadManager } from "@/hooks/use-download-manager"
 
 interface ChatAreaProps {
   messages?: Message[]
@@ -31,6 +33,7 @@ export function ChatArea({
   streamingResponse = "",
 }: ChatAreaProps) {
   const scrollAreaRef = useRef<HTMLDivElement>(null)
+  const { activeDownloads } = useDownloadManager()
 
   useEffect(() => {
     if (scrollAreaRef.current) {
@@ -72,6 +75,13 @@ export function ChatArea({
                   })
                 : ""
 
+              const showDownloadStarter =
+                message.role === "assistant" &&
+                message.onc_api_url &&
+                (!message.dpRequestId ||
+                  (message.dpRequestId &&
+                    activeDownloads[message.dpRequestId]?.status !== "complete"))
+
               return (
                 <div key={message.id}>
                   <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
@@ -99,6 +109,10 @@ export function ChatArea({
                         <TTSButton text={message.content} />
                       </div>
                     </div>
+                  )}
+
+                  {showDownloadStarter && (
+                    <OncApiDownloadStarter oncApiUrl={message.onc_api_url!} />
                   )}
 
                   {message.role === "assistant" &&

--- a/my-next-app/src/components/ChatArea.tsx
+++ b/my-next-app/src/components/ChatArea.tsx
@@ -74,6 +74,8 @@ export function ChatArea({
                     minute: "2-digit",
                   })
                 : ""
+              
+              console.log("url is " + message.onc_api_url);
 
               const showDownloadStarter =
                 message.role === "assistant" &&
@@ -111,8 +113,8 @@ export function ChatArea({
                     </div>
                   )}
 
-                  {showDownloadStarter && (
-                    <OncApiDownloadStarter oncApiUrl={message.onc_api_url!} />
+                  {showDownloadStarter && message.onc_api_url && (
+                    <OncApiDownloadStarter oncApiUrl={message.onc_api_url} />
                   )}
 
                   {message.role === "assistant" &&

--- a/my-next-app/src/components/DownloadCompletePopup.tsx
+++ b/my-next-app/src/components/DownloadCompletePopup.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Download, X, CheckCircle } from "lucide-react"
+
+interface DownloadCompletePopupProps {
+  requestId: string // Changed from dpRequestId to requestId
+  onDownload: () => void
+  onDismiss: () => void
+}
+
+export function DownloadCompletePopup({ requestId, onDownload, onDismiss }: DownloadCompletePopupProps) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-3">
+            <CheckCircle className="h-6 w-6 text-green-500" />
+            <h3 className="text-lg font-semibold text-gray-900">Download Ready!</h3>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onDismiss}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="mb-6">
+          <p className="text-gray-600">Your data product has been generated and is ready for download.</p>
+          <p className="text-sm text-gray-500 mt-2">Request ID: {requestId}</p>
+        </div>
+
+        <div className="flex space-x-3">
+          <Button onClick={onDownload} className="flex-1">
+            <Download className="h-4 w-4 mr-2" />
+            Download File
+          </Button>
+          <Button variant="outline" onClick={onDismiss}>
+            Later
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/my-next-app/src/components/DownloadLinks.tsx
+++ b/my-next-app/src/components/DownloadLinks.tsx
@@ -1,29 +1,30 @@
 "use client"
 
+import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Download, Clock, AlertCircle } from "lucide-react"
 import { useDownloadManager } from "@/hooks/use-download-manager"
 
 interface DownloadLinksProps {
-  dpRequestId: string // This is the request_id from backend
+  dpRequestId: string
   className?: string
 }
 
 export function DownloadLinks({ dpRequestId, className = "" }: DownloadLinksProps) {
   const { activeDownloads, startDownload } = useDownloadManager()
-
-  if (!dpRequestId || dpRequestId === "no" || dpRequestId.trim() === "") {
-    return null
-  }
-
   const downloadJob = activeDownloads[dpRequestId]
+
+  // Ensure polling starts on mount if it hasn't already
+  useEffect(() => {
+    if (!downloadJob) {
+      startDownload(dpRequestId)
+    }
+  }, [dpRequestId, downloadJob, startDownload])
 
   const handleButtonClick = () => {
     if (downloadJob?.status === "complete" && downloadJob.downloadUrl) {
-      // Data is ready - directly open the download URL
       window.open(downloadJob.downloadUrl, "_blank", "noopener,noreferrer")
     } else {
-      // Data not ready - start the download process
       startDownload(dpRequestId)
     }
   }
@@ -32,9 +33,9 @@ export function DownloadLinks({ dpRequestId, className = "" }: DownloadLinksProp
     if (!downloadJob) {
       return {
         icon: <Download className="h-4 w-4" />,
-        text: "Generate Download",
+        text: "Checking Status...",
         variant: "outline" as const,
-        disabled: false,
+        disabled: true,
       }
     }
 
@@ -77,7 +78,7 @@ export function DownloadLinks({ dpRequestId, className = "" }: DownloadLinksProp
       default:
         return {
           icon: <Download className="h-4 w-4" />,
-          text: "Generate Download",
+          text: "Download",
           variant: "outline" as const,
           disabled: false,
         }
@@ -89,7 +90,7 @@ export function DownloadLinks({ dpRequestId, className = "" }: DownloadLinksProp
   return (
     <div className={`mt-3 ${className}`}>
       <div className="text-sm text-gray-600 font-medium mb-2 flex items-center">
-        Data Product Available:
+        Data Product:
         <span className="ml-2 text-xs text-gray-500">ID: {dpRequestId}</span>
       </div>
       <Button

--- a/my-next-app/src/components/DownloadLinks.tsx
+++ b/my-next-app/src/components/DownloadLinks.tsx
@@ -1,40 +1,108 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Download, ExternalLink } from "lucide-react"
+import { Download, Clock, AlertCircle } from "lucide-react"
+import { useDownloadManager } from "@/hooks/use-download-manager"
 
 interface DownloadLinksProps {
-  link: string
+  dpRequestId: string // This is the request_id from backend
   className?: string
 }
 
-export function DownloadLinks({ link, className = "" }: DownloadLinksProps) {
-  if (!link || link === "no" || link.trim() === "") {
+export function DownloadLinks({ dpRequestId, className = "" }: DownloadLinksProps) {
+  const { activeDownloads, startDownload } = useDownloadManager()
+
+  if (!dpRequestId || dpRequestId === "no" || dpRequestId.trim() === "") {
     return null
   }
 
-  const handleDownload = () => {
-    // Open the link in a new tab
-    window.open(link, "_blank", "noopener,noreferrer")
+  const downloadJob = activeDownloads[dpRequestId]
+
+  const handleButtonClick = () => {
+    if (downloadJob?.status === "complete" && downloadJob.downloadUrl) {
+      // Data is ready - directly open the download URL
+      window.open(downloadJob.downloadUrl, "_blank", "noopener,noreferrer")
+    } else {
+      // Data not ready - start the download process
+      startDownload(dpRequestId)
+    }
   }
 
-  const getFileName = (url: string) => {
-    return "Download"
+  const getStatusDisplay = () => {
+    if (!downloadJob) {
+      return {
+        icon: <Download className="h-4 w-4" />,
+        text: "Generate Download",
+        variant: "outline" as const,
+        disabled: false,
+      }
+    }
+
+    switch (downloadJob.status) {
+      case "starting":
+        return {
+          icon: <Clock className="h-4 w-4 animate-spin" />,
+          text: "Starting...",
+          variant: "outline" as const,
+          disabled: true,
+        }
+      case "queued":
+        return {
+          icon: <Clock className="h-4 w-4" />,
+          text: "Queued",
+          variant: "outline" as const,
+          disabled: true,
+        }
+      case "running":
+        return {
+          icon: <Clock className="h-4 w-4 animate-pulse" />,
+          text: "Generating...",
+          variant: "outline" as const,
+          disabled: true,
+        }
+      case "complete":
+        return {
+          icon: <Download className="h-4 w-4" />,
+          text: "Download Ready",
+          variant: "default" as const,
+          disabled: false,
+        }
+      case "error":
+        return {
+          icon: <AlertCircle className="h-4 w-4" />,
+          text: "Error",
+          variant: "destructive" as const,
+          disabled: true,
+        }
+      default:
+        return {
+          icon: <Download className="h-4 w-4" />,
+          text: "Generate Download",
+          variant: "outline" as const,
+          disabled: false,
+        }
+    }
   }
+
+  const statusDisplay = getStatusDisplay()
 
   return (
     <div className={`mt-3 ${className}`}>
-      <div className="text-sm text-gray-600 font-medium mb-2">Available Download:</div>
+      <div className="text-sm text-gray-600 font-medium mb-2 flex items-center">
+        Data Product Available:
+        <span className="ml-2 text-xs text-gray-500">ID: {dpRequestId}</span>
+      </div>
       <Button
-        variant="outline"
+        variant={statusDisplay.variant}
         size="sm"
-        onClick={handleDownload}
-        className="text-sm bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100 hover:border-blue-300"
+        onClick={handleButtonClick}
+        disabled={statusDisplay.disabled}
+        className="text-sm bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100 hover:border-blue-300 disabled:opacity-50"
       >
-        <Download className="h-4 w-4 mr-2" />
-        {getFileName(link)}
-        <ExternalLink className="h-3 w-3 ml-1 opacity-60" />
+        {statusDisplay.icon}
+        <span className="ml-2">{statusDisplay.text}</span>
       </Button>
+      {downloadJob?.message && <p className="text-xs text-gray-500 mt-1">{downloadJob.message}</p>}
     </div>
   )
 }

--- a/my-next-app/src/components/OncDownloadStarter.tsx
+++ b/my-next-app/src/components/OncDownloadStarter.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { dataProductService } from "@/lib/data-product-service"
+
+interface OncApiDownloadStarterProps {
+  oncApiUrl: string
+}
+
+interface DataProduct {
+  dataProductCode: string
+  dataProductName: string
+  extension: string
+}
+
+export default function OncApiDownloadStarter({ oncApiUrl }: OncApiDownloadStarterProps) {
+  const [locationCode, setLocationCode] = useState<string>("")
+  const [deviceCategoryCode, setDeviceCategoryCode] = useState<string>("")
+  const [token, setToken] = useState<string>("")
+  const [dateFrom, setDateFrom] = useState<string>("")
+  const [dateTo, setDateTo] = useState<string>("")
+
+  const [dataProducts, setDataProducts] = useState<DataProduct[]>([])
+  const [selectedKey, setSelectedKey] = useState<string>("")
+  const [selectedProductCode, setSelectedProductCode] = useState<string>("")
+  const [selectedProductExtension, setSelectedProductExtension] = useState<string>("")
+
+  const [requesting, setRequesting] = useState(false)
+  const [dpRequestId, setDpRequestId] = useState<string>("")
+  const [downloadUrl, setDownloadUrl] = useState<string>("")
+  const [error, setError] = useState<string>("")
+
+  const [showPanel, setShowPanel] = useState(false)
+
+  useEffect(() => {
+    try {
+      const url = new URL(oncApiUrl)
+      setLocationCode(url.searchParams.get("locationCode") || "")
+      setDeviceCategoryCode(url.searchParams.get("deviceCategoryCode") || "")
+      setToken(url.searchParams.get("token") || "")
+      setDateFrom(url.searchParams.get("dateFrom") || "")
+      setDateTo(url.searchParams.get("dateTo") || "")
+    } catch (e) {
+      setError("Invalid ONC API URL")
+    }
+  }, [oncApiUrl])
+
+  useEffect(() => {
+    async function fetchDataProducts() {
+      if (!locationCode || !deviceCategoryCode || !token) return
+      setError("")
+      try {
+        const response = await fetch(
+          `https://data.oceannetworks.ca/api/dataProducts?locationCode=${locationCode}&deviceCategoryCode=${deviceCategoryCode}&token=${token}`,
+          { headers: { accept: "application/json" } }
+        )
+        if (!response.ok) throw new Error(`API error: ${response.status}`)
+
+        const products = await response.json()
+        const filtered = products
+          .filter((p: any) => p.dataProductCode && p.extension)
+          .map((p: any) => ({
+            dataProductCode: p.dataProductCode,
+            dataProductName: p.dataProductName,
+            extension: p.extension,
+          }))
+
+        setDataProducts(filtered)
+        setSelectedKey("")
+        setSelectedProductCode("")
+        setSelectedProductExtension("")
+        setDpRequestId("")
+        setDownloadUrl("")
+      } catch (e: any) {
+        setError(e.message || "Failed to fetch data products")
+      }
+    }
+    fetchDataProducts()
+  }, [locationCode, deviceCategoryCode, token])
+
+  useEffect(() => {
+    if (selectedKey) {
+      const [code, ext] = selectedKey.split("::")
+      setSelectedProductCode(code)
+      setSelectedProductExtension(ext)
+    } else {
+      setSelectedProductCode("")
+      setSelectedProductExtension("")
+    }
+  }, [selectedKey])
+
+  async function handleRequestDownload() {
+    if (!selectedProductCode || !selectedProductExtension) {
+      setError("Please select a data product")
+      return
+    }
+    setError("")
+    setRequesting(true)
+
+    try {
+      const url = new URL("https://data.oceannetworks.ca/api/dataProductDelivery/request")
+      url.searchParams.set("locationCode", locationCode)
+      url.searchParams.set("deviceCategoryCode", deviceCategoryCode)
+      url.searchParams.set("dataProductCode", selectedProductCode)
+      url.searchParams.set("extension", selectedProductExtension)
+      if (dateFrom) url.searchParams.set("dateFrom", dateFrom)
+      if (dateTo) url.searchParams.set("dateTo", dateTo)
+      url.searchParams.set("token", token)
+
+      const response = await fetch(url.toString(), { headers: { accept: "application/json" } })
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`)
+      const data = await response.json()
+
+      if (data.dpRequestId) {
+        setDpRequestId(String(data.dpRequestId))
+      } else {
+        throw new Error("No dpRequestId returned")
+      }
+    } catch (e: any) {
+      setError(e.message || "Failed to request download")
+    } finally {
+      setRequesting(false)
+    }
+  }
+
+  async function handleDownload() {
+    if (!dpRequestId) return
+    try {
+      const link = await dataProductService.getDataDownloadLink(dpRequestId)
+      setDownloadUrl(link)
+      window.open(link, "_blank", "noopener,noreferrer")
+    } catch (e: any) {
+      setError(e.message || "Failed to get download link")
+    }
+  }
+
+  return (
+    <div>
+      <Button size="sm" variant="outline" onClick={() => setShowPanel((prev) => !prev)}>
+        {showPanel ? "Hide Download Options" : "Show Download Options"}
+      </Button>
+
+      {showPanel && (
+        <div className="border rounded p-3 bg-gray-50 max-w-md mt-2">
+          {error && <p className="text-red-600 mb-2">{error}</p>}
+
+          {!dpRequestId ? (
+            <>
+              <label className="block mb-1 font-medium" htmlFor="dataProductSelect">
+                Select Data Product:
+              </label>
+              <select
+                id="dataProductSelect"
+                className="w-full mb-3 p-2 border rounded"
+                value={selectedKey}
+                onChange={(e) => setSelectedKey(e.target.value)}
+                disabled={requesting || dataProducts.length === 0}
+              >
+                <option value="">-- Choose a product --</option>
+                {dataProducts.map(({ dataProductCode, dataProductName, extension }) => {
+                  const key = `${dataProductCode}::${extension}`
+                  return (
+                    <option key={key} value={key}>
+                      {dataProductName} ({extension})
+                    </option>
+                  )
+                })}
+              </select>
+
+              <Button
+                onClick={handleRequestDownload}
+                disabled={requesting || !selectedProductCode || !selectedProductExtension}
+                className="w-full"
+              >
+                {requesting ? "Requesting..." : "Request Data"}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={handleDownload} className="w-full" variant="default">
+              Download Ready - Click to Download
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/my-next-app/src/hooks/use-chat-api.ts
+++ b/my-next-app/src/hooks/use-chat-api.ts
@@ -226,6 +226,7 @@ export function useChatAPI() {
         messageId: aiResponse.message_id.toString(),
         feedback: aiResponse.feedback,
         dpRequestId: dpRequestId,
+        onc_api_url: aiResponse.onc_api_url,
       }
 
       setCurrentChat((prev: Chat | null) =>

--- a/my-next-app/src/hooks/use-chat-api.ts
+++ b/my-next-app/src/hooks/use-chat-api.ts
@@ -130,6 +130,7 @@ export function useChatAPI() {
             messageId: aiResponse.message_id.toString(),
             feedback: aiResponse.feedback,
             dpRequestId: dpRequestId,
+            onc_api_url: aiResponse.onc_api_url,
           },
         ],
       };

--- a/my-next-app/src/hooks/use-chat-api.ts
+++ b/my-next-app/src/hooks/use-chat-api.ts
@@ -139,11 +139,14 @@ export function useChatAPI() {
       // Step 2: Send the first message to get AI response
       const aiResponse = await chatAPI.sendMessage(firstMessage, newConversation.conversation_id)
 
-      // Process download link - only include if it's not "no" and is a valid string
-      let downloadLink: string | undefined = undefined
-      if (aiResponse.download_link && aiResponse.download_link !== "no" && aiResponse.download_link.trim() !== "") {
-        downloadLink = aiResponse.download_link
-        console.log("Found download link in new chat:", downloadLink)
+      // Process request_id
+      let dpRequestId: string | undefined = undefined
+
+      console.log("Processing request_id from new chat response:", aiResponse.request_id)
+
+      if (aiResponse.request_id && aiResponse.request_id > 0) {
+        dpRequestId = aiResponse.request_id.toString()
+        console.log("Found request_id in new chat:", dpRequestId)
       }
 
       // Step 3: Create the chat object with both messages
@@ -161,13 +164,13 @@ export function useChatAPI() {
             messageId: aiResponse.message_id.toString(),
           },
           {
-            id: `${aiResponse.message_id}`,
+            id: `assistant-${aiResponse.message_id}`,
             content: aiResponse.response,
             role: "assistant",
             timestamp: new Date(),
             messageId: aiResponse.message_id.toString(),
             feedback: aiResponse.feedback,
-            downloadLink: downloadLink,
+            dpRequestId: dpRequestId,
           },
         ],
       }
@@ -269,11 +272,14 @@ export function useChatAPI() {
       // Send to API
       const aiResponse = await chatAPI.sendMessage(content, chatId)
 
-      // Process download link - only include if it's not "no" and is a valid string
-      let downloadLink: string | undefined = undefined
-      if (aiResponse.download_link && aiResponse.download_link !== "no" && aiResponse.download_link.trim() !== "") {
-        downloadLink = aiResponse.download_link
-        console.log("Found download link in message response:", downloadLink)
+      // Process request_id
+      let dpRequestId: string | undefined = undefined
+
+      console.log("Processing request_id from message response:", aiResponse.request_id)
+
+      if (aiResponse.request_id && aiResponse.request_id > 0) {
+        dpRequestId = aiResponse.request_id.toString()
+        console.log("Found request_id in message response:", dpRequestId)
       }
 
       // Create real messages using the API response format
@@ -286,13 +292,13 @@ export function useChatAPI() {
       }
 
       const assistantMessage: Message = {
-        id: `${aiResponse.message_id}`,
+        id: `assistant-${aiResponse.message_id}`,
         content: aiResponse.response,
         role: "assistant",
         timestamp: new Date(),
         messageId: aiResponse.message_id.toString(),
         feedback: aiResponse.feedback,
-        downloadLink: downloadLink,
+        dpRequestId: dpRequestId,
       }
 
       // Update chat with real messages

--- a/my-next-app/src/hooks/use-download-manager.ts
+++ b/my-next-app/src/hooks/use-download-manager.ts
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState, useEffect, useRef, useCallback } from "react"
+import { dataProductService } from "@/lib/data-product-service"
+
+interface DownloadJob {
+  requestId: string
+  status: "starting" | "queued" | "running" | "complete" | "error"
+  message?: string
+  downloadUrl?: string
+  startTime: Date
+}
+
+export function useDownloadManager() {
+  const [activeDownloads, setActiveDownloads] = useState<{ [key: string]: DownloadJob }>({})
+  const [completedDownloads, setCompletedDownloads] = useState<string[]>([])
+  const pollIntervals = useRef<{ [key: string]: NodeJS.Timeout }>({})
+
+  const startDownload = useCallback(async (requestId: string) => {
+    console.log(`Starting download for request_id: ${requestId}`)
+
+    // Add to active downloads
+    setActiveDownloads((prev) => ({
+      ...prev,
+      [requestId]: {
+        requestId,
+        status: "starting",
+        startTime: new Date(),
+      },
+    }))
+
+    try {
+      // Start the download process (this is mostly just logging)
+      await dataProductService.startDownloadProcess(requestId)
+
+      // Update status to queued and start polling
+      setActiveDownloads((prev) => ({
+        ...prev,
+        [requestId]: {
+          ...prev[requestId],
+          status: "queued",
+        },
+      }))
+
+      // Start polling for status
+      startPolling(requestId)
+    } catch (error) {
+      console.error(`Failed to start download for ${requestId}:`, error)
+      setActiveDownloads((prev) => ({
+        ...prev,
+        [requestId]: {
+          ...prev[requestId],
+          status: "error",
+          message: error instanceof Error ? error.message : "Failed to start download",
+        },
+      }))
+    }
+  }, [])
+
+  const startPolling = useCallback((requestId: string) => {
+    // Clear any existing interval
+    if (pollIntervals.current[requestId]) {
+      clearInterval(pollIntervals.current[requestId])
+    }
+
+    console.log(`Starting polling for request_id: ${requestId}`)
+
+    pollIntervals.current[requestId] = setInterval(async () => {
+      try {
+        const status = await dataProductService.checkStatus(requestId)
+        console.log(`Status update for ${requestId}:`, status)
+
+        setActiveDownloads((prev) => {
+          const current = prev[requestId]
+          if (!current) return prev
+
+          return {
+            ...prev,
+            [requestId]: {
+              ...current,
+              status: status.status,
+              message: status.message,
+              downloadUrl: status.downloadUrl,
+            },
+          }
+        })
+
+        // If complete or error, stop polling and move to completed
+        if (status.status === "complete" || status.status === "error") {
+          clearInterval(pollIntervals.current[requestId])
+          delete pollIntervals.current[requestId]
+
+          if (status.status === "complete") {
+            setCompletedDownloads((prev) => [...prev, requestId])
+          }
+        }
+      } catch (error) {
+        console.error(`Failed to check status for ${requestId}:`, error)
+        // Continue polling on error, don't stop
+      }
+    }, 3000) // Poll every 3 seconds (slightly faster than backend's 2 second intervals)
+  }, [])
+
+  const dismissCompleted = useCallback((requestId: string) => {
+    setCompletedDownloads((prev) => prev.filter((id) => id !== requestId))
+    setActiveDownloads((prev) => {
+      const { [requestId]: removed, ...rest } = prev
+      return rest
+    })
+  }, [])
+
+  // Cleanup intervals on unmount
+  useEffect(() => {
+    return () => {
+      Object.values(pollIntervals.current).forEach((interval) => {
+        clearInterval(interval)
+      })
+    }
+  }, [])
+
+  return {
+    activeDownloads,
+    completedDownloads,
+    startDownload,
+    dismissCompleted,
+  }
+}

--- a/my-next-app/src/lib/api.ts
+++ b/my-next-app/src/lib/api.ts
@@ -486,3 +486,10 @@ const chatAPI = new ChatAPI()
 
 // Export the functions and instance
 export { chatAPI, convertApiConversation }
+
+// API for the admin
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+});
+
+export default api;

--- a/my-next-app/src/lib/api.ts
+++ b/my-next-app/src/lib/api.ts
@@ -22,7 +22,7 @@ export class ChatAPI {
   constructor(baseUrl: string = API_BASE_URL) {
     this.client = axios.create({
       baseURL: baseUrl,
-      timeout: 60000, // 60 seconds timeout for LLM responses
+      timeout: 6000000000000,
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",

--- a/my-next-app/src/lib/api.ts
+++ b/my-next-app/src/lib/api.ts
@@ -8,11 +8,12 @@ import type {
   MessageRequest,
   MessageResponse,
   FeedbackRequest,
+  UserInfo,
 } from "@/types/chat"
 
 // API configuration
 const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || ""
+  process.env.NEXT_PUBLIC_API_URL || "https://nautichat-api-1050974581549.northamerica-northeast1.run.app"
 
 // API client class
 export class ChatAPI {
@@ -21,7 +22,7 @@ export class ChatAPI {
   constructor(baseUrl: string = API_BASE_URL) {
     this.client = axios.create({
       baseURL: baseUrl,
-      timeout: 600000000, // 60 seconds timeout for LLM responses
+      timeout: 60000, // 60 seconds timeout for LLM responses
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
@@ -152,6 +153,31 @@ export class ChatAPI {
     }
     console.log("No user_id found")
     return null
+  }
+
+  // GET /auth/me - Get current user info including ONC token
+  async getUserInfo(): Promise<UserInfo> {
+    try {
+      console.log("Fetching user info...")
+
+      const response = await this.client.get<UserInfo>("/auth/me")
+      console.log("User info received:", { ...response.data, onc_token: "[REDACTED]" })
+      return response.data
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          throw new Error("Authentication failed. Please log in again.")
+        }
+        if (error.code === "NETWORK_ERROR" || error.message === "Network Error") {
+          throw new Error(
+            "Unable to connect to the server. Please check if the API is running and CORS is configured properly.",
+          )
+        }
+        const errorDetail = error.response?.data?.detail || error.message
+        throw new Error(`Failed to fetch user info: ${errorDetail}`)
+      }
+      throw new Error("Failed to fetch user info: Unknown error")
+    }
   }
 
   // POST /llm/conversations - Create a new conversation
@@ -315,13 +341,6 @@ export class ChatAPI {
     }
   }
 
-  // GET /auth/me - Get current user info
-  async getCurrentUser(): Promise<{ id: number; username: string; onc_token: string; is_admin: boolean }> {
-    const response = await this.client.get("/auth/me");
-    return response.data;
-  }
-
-
   // GET /llm/conversations/{conversation_id} - Get a specific conversation
   async getConversation(conversationId: string): Promise<ApiConversation> {
     try {
@@ -392,11 +411,8 @@ export class ChatAPI {
   }
 }
 
-// Create a singleton instance
-export const chatAPI = new ChatAPI()
-
 // Helper function to convert API message to local message format
-export function convertApiMessage(apiMessage: ApiMessage): Message[] {
+function convertApiMessage(apiMessage: ApiMessage): Message[] {
   // Convert the API message format to our local format
   // Each API message contains both user input and assistant response
   const messages: Message[] = []
@@ -410,21 +426,32 @@ export function convertApiMessage(apiMessage: ApiMessage): Message[] {
     messageId: apiMessage.message_id.toString(),
   })
 
-  // Add assistant message
+  // Process request_id (data product request)
+  let dpRequestId: string | undefined = undefined
+
+  console.log("Processing API message request_id:", apiMessage.request_id)
+
+  if (apiMessage.request_id && apiMessage.request_id > 0) {
+    dpRequestId = apiMessage.request_id.toString()
+    console.log("Found request_id:", dpRequestId)
+  }
+
+  // Add assistant message with request_id
   messages.push({
-    id: `${apiMessage.message_id}`,
+    id: `assistant-${apiMessage.message_id}`,
     content: apiMessage.response,
     role: "assistant",
     timestamp: new Date(), // Use current time since API doesn't provide timestamps
     messageId: apiMessage.message_id.toString(),
     feedback: apiMessage.feedback,
+    dpRequestId: dpRequestId,
   })
 
   return messages
 }
 
 // Helper function to convert API conversation to local chat format
-export function convertApiConversation(apiConversation: ApiConversation) {
+function convertApiConversation(apiConversation: ApiConversation) {
   console.log("Converting API conversation:", apiConversation)
 
   // Flatten all messages from API format
@@ -454,9 +481,8 @@ export function convertApiConversation(apiConversation: ApiConversation) {
   return convertedChat
 }
 
+// Create a singleton instance
+const chatAPI = new ChatAPI()
 
-const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
-});
-
-export default api;
+// Export the functions and instance
+export { chatAPI, convertApiConversation }

--- a/my-next-app/src/lib/api.ts
+++ b/my-next-app/src/lib/api.ts
@@ -445,6 +445,7 @@ function convertApiMessage(apiMessage: ApiMessage): Message[] {
     messageId: apiMessage.message_id.toString(),
     feedback: apiMessage.feedback,
     dpRequestId: dpRequestId,
+    onc_api_url: apiMessage.onc_api_url,
   })
 
   return messages

--- a/my-next-app/src/lib/data-product-service.ts
+++ b/my-next-app/src/lib/data-product-service.ts
@@ -1,0 +1,156 @@
+import axios from "axios"
+import { chatAPI } from "./api"
+import type { ONCDataProductResponse } from "@/types/chat"
+
+export interface DataProductStatus {
+  status: "queued" | "running" | "complete" | "error"
+  message?: string
+  downloadUrl?: string
+}
+
+export interface DataProductRunResponse {
+  success: boolean
+  message?: string
+}
+
+class DataProductService {
+  private oncToken: string | null = null
+
+  // Get and cache the ONC token
+  private async getONCToken(): Promise<string> {
+    if (this.oncToken) {
+      return this.oncToken
+    }
+
+    try {
+      const userInfo = await chatAPI.getUserInfo()
+      this.oncToken = userInfo.onc_token
+      console.log("Retrieved ONC token from user info")
+      return this.oncToken
+    } catch (error) {
+      console.error("Failed to get ONC token:", error)
+      throw new Error("Failed to get ONC token")
+    }
+  }
+
+  // Emulate the backend function: get_data_download_link
+  async getDataDownloadLink(requestId: string): Promise<string> {
+    try {
+      console.log(`Getting data download link for request_id: ${requestId}`)
+
+      const oncToken = await this.getONCToken()
+
+      // Poll the Ocean Networks Canada API (up to 10 times)
+      for (let attempt = 1; attempt <= 10; attempt++) {
+        console.log(`Polling attempt ${attempt}/10 for request_id: ${requestId}`)
+
+        const url = `https://data.oceannetworks.ca/api/dataProductDelivery/run?dpRequestId=${requestId}&token=${oncToken}`
+
+        try {
+          const response = await axios.get(url, { timeout: 10000 })
+          console.log(`ONC API response (attempt ${attempt}):`, response.data)
+
+          // The response should be an array with one element
+          const data: ONCDataProductResponse = Array.isArray(response.data) ? response.data[0] : response.data
+
+          if (data.status === "complete" && data.dpRunId) {
+            // Request is complete, form the download link
+            const runId = data.dpRunId
+            const index = 1 // Currently hardcoded (will download the first file available)
+            const downloadUrl = `https://data.oceannetworks.ca/api/dataProductDelivery/download?dpRunId=${runId}&index=${index}&token=${oncToken}`
+
+            console.log(`Download link ready for request_id ${requestId}:`, downloadUrl)
+            return downloadUrl
+          } else {
+            console.log(`Request ${requestId} not ready yet, status: ${data.status}`)
+            // Wait 2 seconds before next attempt
+            if (attempt < 10) {
+              await new Promise((resolve) => setTimeout(resolve, 2000))
+            }
+          }
+        } catch (apiError) {
+          console.error(`ONC API error on attempt ${attempt}:`, apiError)
+          if (attempt < 10) {
+            await new Promise((resolve) => setTimeout(resolve, 2000))
+          }
+        }
+      }
+
+      // If we get here, we've exhausted all attempts
+      throw new Error(`Failed to get download link for request_id ${requestId} after 10 attempts`)
+    } catch (error) {
+      console.error("Failed to get data download link:", error)
+      throw error
+    }
+  }
+
+  // Check status of a data product request
+  async checkStatus(requestId: string): Promise<DataProductStatus> {
+    try {
+      console.log(`Checking status for request_id: ${requestId}`)
+
+      const oncToken = await this.getONCToken()
+      const url = `https://data.oceannetworks.ca/api/dataProductDelivery/run?dpRequestId=${requestId}&token=${oncToken}`
+
+      const response = await axios.get(url, { timeout: 10000 })
+      console.log("ONC API status response:", response.data)
+
+      // The response should be an array with one element
+      const data: ONCDataProductResponse = Array.isArray(response.data) ? response.data[0] : response.data
+
+      if (data.status === "complete" && data.dpRunId) {
+        // Generate the download URL
+        const runId = data.dpRunId
+        const index = 1
+        const downloadUrl = `https://data.oceannetworks.ca/api/dataProductDelivery/download?dpRunId=${runId}&index=${index}&token=${oncToken}`
+
+        return {
+          status: "complete",
+          downloadUrl: downloadUrl,
+          message: "Download ready",
+        }
+      } else if (data.status === "running") {
+        return {
+          status: "running",
+          message: "Processing data product...",
+        }
+      } else if (data.status === "queued") {
+        return {
+          status: "queued",
+          message: "Request queued for processing",
+        }
+      } else {
+        return {
+          status: "error",
+          message: data.message || "Unknown error occurred",
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check data product status:", error)
+      return {
+        status: "error",
+        message: "Failed to check status",
+      }
+    }
+  }
+
+  // Start the download process (this just triggers the first status check)
+  async startDownloadProcess(requestId: string): Promise<void> {
+    try {
+      console.log(`Starting download process for request_id: ${requestId}`)
+      // The process is already started by the backend when it returns the request_id
+      // We just need to start polling for status
+      console.log(`Download process initiated for request_id ${requestId}`)
+    } catch (error) {
+      console.error("Failed to start download process:", error)
+      throw error
+    }
+  }
+
+  // Clear cached token (useful for logout or token refresh)
+  clearToken(): void {
+    this.oncToken = null
+  }
+}
+
+export const dataProductService = new DataProductService()

--- a/my-next-app/src/lib/data-product-service.ts
+++ b/my-next-app/src/lib/data-product-service.ts
@@ -63,9 +63,9 @@ class DataProductService {
             return downloadUrl
           } else {
             console.log(`Request ${requestId} not ready yet, status: ${data.status}`)
-            // Wait 2 seconds before next attempt
+            // Wait 10 seconds before next attempt
             if (attempt < 10) {
-              await new Promise((resolve) => setTimeout(resolve, 2000))
+              await new Promise((resolve) => setTimeout(resolve, 10000))
             }
           }
         } catch (apiError) {

--- a/my-next-app/src/types/chat.ts
+++ b/my-next-app/src/types/chat.ts
@@ -8,7 +8,7 @@ export interface Message {
     rating: number
     comment: string
   }
-  downloadLink?: string
+  dpRequestId?: string
 }
 
 export interface Chat {
@@ -31,11 +31,11 @@ export interface ApiMessage {
   user_id: number
   input: string
   response: string
+  request_id?: number // Only data product request ID
   feedback?: {
     rating: number
     comment: string
   }
-  download_link?: string
 }
 
 export interface ApiConversation {
@@ -65,11 +65,11 @@ export interface MessageResponse {
   user_id: number
   input: string
   response: string
+  request_id?: number // Only data product request ID
   feedback?: {
     rating: number
     comment: string
   }
-  download_link?: string
 }
 
 export interface FeedbackRequest {
@@ -79,4 +79,31 @@ export interface FeedbackRequest {
 
 export interface ConversationsResponse {
   conversations: ApiConversation[]
+}
+
+// User info from /auth/me endpoint
+export interface UserInfo {
+  id: number
+  username: string
+  onc_token: string
+  is_admin: boolean
+}
+
+// Ocean Networks Canada API response types
+export interface ONCDataProductResponse {
+  status: string
+  dpRunId?: string
+  message?: string
+}
+
+// Types for data product delivery
+export interface DataProductStatus {
+  status: "queued" | "running" | "complete" | "error"
+  message?: string
+  downloadUrl?: string
+}
+
+export interface DataProductRunResponse {
+  success: boolean
+  message?: string
 }

--- a/my-next-app/src/types/chat.ts
+++ b/my-next-app/src/types/chat.ts
@@ -9,6 +9,7 @@ export interface Message {
     comment: string
   }
   dpRequestId?: string
+  onc_api_url?: string
 }
 
 export interface Chat {
@@ -36,6 +37,7 @@ export interface ApiMessage {
     rating: number
     comment: string
   }
+  onc_api_url?: string
 }
 
 export interface ApiConversation {

--- a/my-next-app/src/types/chat.ts
+++ b/my-next-app/src/types/chat.ts
@@ -72,6 +72,7 @@ export interface MessageResponse {
     rating: number
     comment: string
   }
+  onc_api_url?: string
 }
 
 export interface FeedbackRequest {


### PR DESCRIPTION
Last sprint, the backend would wait for the data download to completely finish before returning. These changes reflect that instead of looking at the download links from the backend, that we now take the request ID from the backend and make our own poll to the ONC url to check if the data download is ready. The user can continue on with chatting until it is done.

To test:

1. Send the following to the chatbot: " I want to download dive computer data as a LF in txt from August 20th 2015"
2. Then the chatbot should return with a button that has "Generate download"
3. Click that
4. Then the button should display "Queued"
5. Then once its done, the same button should say "download is ready"